### PR TITLE
Code review required

### DIFF
--- a/hifive-test-explorer/src/main/java/com/htmlhifive/testexplorer/api/ImageController.java
+++ b/hifive-test-explorer/src/main/java/com/htmlhifive/testexplorer/api/ImageController.java
@@ -101,16 +101,13 @@ public class ImageController {
 			BufferedImage image = ImageIO.read(getFile(screenshot));
 			EdgeDetector edgeDetector = new EdgeDetector(0.5);
 
-			switch (colorIndex)
-			{
-				case 0:
-					edgeDetector.setBackgroundColor(new Color(0, 0, 0, 255));
-					edgeDetector.setForegroundColor(new Color(255, 0, 0, 255));
-					break;
-				case 1:
-					edgeDetector.setBackgroundColor(new Color(0, 0, 0, 0));
-					edgeDetector.setForegroundColor(new Color(0, 0, 255, 128));
-					break;
+			switch (colorIndex) {
+			case 0:
+				edgeDetector.setForegroundColor(new Color(255, 0, 0, 255));
+				break;
+			case 1:
+				edgeDetector.setForegroundColor(new Color(0, 0, 255, 255));
+				break;
 			}
 
 			BufferedImage edgeImage = edgeDetector.DetectEdge(image);

--- a/hifive-test-explorer/src/main/java/com/htmlhifive/testexplorer/image/EdgeDetector.java
+++ b/hifive-test-explorer/src/main/java/com/htmlhifive/testexplorer/image/EdgeDetector.java
@@ -59,8 +59,8 @@ public class EdgeDetector {
         this.thresholdHigh = 1.0 / 40 / sigma;
         this.thresholdLow = 1.0 / 90 / sigma;
 
-        this.backgroundColor = Color.black;
-        this.foregroundColor = Color.white;
+        this.backgroundColor = new Color(255, 255, 255, 0);
+        this.foregroundColor = Color.black;
     }
 
     /**

--- a/hifive-test-explorer/src/main/webapp/diff.html
+++ b/hifive-test-explorer/src/main/webapp/diff.html
@@ -114,14 +114,7 @@
 
 					<div class="tab-pane" id="edge-overlapping">
 						<div class="row">
-							<div class="col-xs-12 image-diff image-overlay">
-								<div class="expected-edge">
-									<img>
-								</div>
-								<div class="actual-edge">
-									<img>
-								</div>
-							</div>
+							<div class="col-xs-12 image-diff image-overlay"><canvas></div>
 						</div>
 					</div>
 

--- a/hifive-test-explorer/src/main/webapp/diff.html
+++ b/hifive-test-explorer/src/main/webapp/diff.html
@@ -114,7 +114,10 @@
 
 					<div class="tab-pane" id="edge-overlapping">
 						<div class="row">
-							<div class="col-xs-12 image-diff image-overlay"><canvas></div>
+							<div class="col-xs-12 image-diff image-overlay">
+								<div class="large"></div>
+								<canvas class="small">
+							</div>
 						</div>
 					</div>
 

--- a/hifive-test-explorer/src/main/webapp/src/diff.css
+++ b/hifive-test-explorer/src/main/webapp/src/diff.css
@@ -67,3 +67,7 @@ body {
 	left: 0;
 	top: 0;
 }
+
+.image-overlay .expected-edge > img {
+	mix-blend-mode: multiply;
+}

--- a/hifive-test-explorer/src/main/webapp/src/diff.css
+++ b/hifive-test-explorer/src/main/webapp/src/diff.css
@@ -59,3 +59,24 @@ body {
 	width: 1px;
 	background-color: gray;
 }
+
+#edge-overlapping .large {
+	width: 175px;
+	height: 175px;
+	position: absolute;
+	border-radius: 100%;
+
+	background-color: white;
+	background-repeat: no-repeat;
+
+	box-shadow:
+		0 0 0 7px rgba(255, 255, 255, 0.85),
+		0 0 7px 7px rgba(0, 0, 0, 0.25),
+		inset 0 0 40px 2px rgba(0, 0, 0, 0.25);
+
+	display: none;
+}
+
+#edge-overlapping canvas {
+	max-width: 100%;
+}

--- a/hifive-test-explorer/src/main/webapp/src/diff.css
+++ b/hifive-test-explorer/src/main/webapp/src/diff.css
@@ -59,15 +59,3 @@ body {
 	width: 1px;
 	background-color: gray;
 }
-
-.image-overlay .expected-edge {
-	position: absolute;
-	overflow: hidden;
-	width: 100%;
-	left: 0;
-	top: 0;
-}
-
-.image-overlay .expected-edge > img {
-	mix-blend-mode: multiply;
-}

--- a/hifive-test-explorer/src/main/webapp/src/diff.js
+++ b/hifive-test-explorer/src/main/webapp/src/diff.js
@@ -197,31 +197,48 @@
 
 				var context = canvas.getContext('2d');
 				context.globalCompositeOperation = 'multiply';
-				context.drawImage(expected, 0, 0);
-				context.drawImage(actual, 0, 0);
-
-				// Image magnifier
-				$('.large').css('background-image', 'url('+canvas.toDataURL('image/png')+')');
-				$('#edge-overlapping .image-overlay').mousemove(function(e) {
-					var magnify_offset = $(this).offset();
-					var mx = e.pageX - magnify_offset.left;
-					var my = e.pageY - magnify_offset.top;
-
-					if(mx < $(this).width() && my < $(this).height() && mx > 0 && my > 0) {
-						$('.large').fadeIn(100);
-					} else {
-						$('.large').fadeOut(100);
-					} if($('.large').is(':visible')) {
-						var rx = Math.round(mx/$('.small').width()*native_width - $('.large').width()/2)*-1;
-						var ry = Math.round(my/$('.small').height()*native_height - $('.large').height()/2)*-1;
-
-						$('.large').css({
-							left: mx - $('.large').width()/2,
-							top: my - $('.large').height()/2,
-							backgroundPosition: rx + 'px ' + ry + 'px'
-						});
+				if (context.globalCompositeOperation == 'multiply') {
+					context.drawImage(expected, 0, 0);
+					context.drawImage(actual, 0, 0);
+					initImageMagnifier();
+				} else {
+					// IE workaround
+					var actualBlack = new Image();
+					actualBlack.onload = function() {
+						context.drawImage(expected, 0, 0);
+						context.globalCompositeOperation = 'source-atop';
+						context.drawImage(actualBlack, 0, 0);
+						context.globalCompositeOperation = 'destination-over';
+						context.drawImage(actual, 0, 0);
+						initImageMagnifier();
 					}
-				})
+					actualBlack.src = format('image/getEdge', { id: actualId, colorIndex: 2 });
+				}
+
+				function initImageMagnifier() {
+					// Image magnifier
+					$('.large').css('background-image', 'url('+canvas.toDataURL('image/png')+')');
+					$('#edge-overlapping .image-overlay').mousemove(function(e) {
+						var magnify_offset = $(this).offset();
+						var mx = e.pageX - magnify_offset.left;
+						var my = e.pageY - magnify_offset.top;
+
+						if(mx < $(this).width() && my < $(this).height() && mx > 0 && my > 0) {
+							$('.large').fadeIn(100);
+						} else {
+							$('.large').fadeOut(100);
+						} if($('.large').is(':visible')) {
+							var rx = Math.round(mx/$('.small').width()*native_width - $('.large').width()/2)*-1;
+							var ry = Math.round(my/$('.small').height()*native_height - $('.large').height()/2)*-1;
+
+							$('.large').css({
+								left: mx - $('.large').width()/2,
+								top: my - $('.large').height()/2,
+								backgroundPosition: rx + 'px ' + ry + 'px'
+							});
+						}
+				});
+			}
 			});
 		},
 

--- a/hifive-test-explorer/src/main/webapp/src/diff.js
+++ b/hifive-test-explorer/src/main/webapp/src/diff.js
@@ -4,7 +4,7 @@
 (function($) {
 	/**
 	 * This class is a &qout;logic&quot; for the test result comparison page.
-	 * 
+	 *
 	 * @class
 	 * @memberOf hifive.test.explorer.logic
 	 * @name TestResultDiffLogic
@@ -17,7 +17,7 @@
 
 		/**
 		 * Get details of the test result.
-		 * 
+		 *
 		 * @memberOf hifive.test.explorer.logic.TestResultDiffLogic
 		 * @param {string} id the id of the test result
 		 * @returns {JqXHRWrapper}
@@ -34,7 +34,7 @@
 
 		/**
 		 * Get the ID of the right screenshot of the test result.
-		 * 
+		 *
 		 * @memberOf hifive.test.explorer.logic.TestResultDiffLogic
 		 * @param {string} id the id of the test result
 		 * @returns {JqXHRWrapper}
@@ -55,7 +55,7 @@
 (function($) {
 	/**
 	 * This class is a controller for the test result comparison page.
-	 * 
+	 *
 	 * @class
 	 * @memberOf hifive.test.explorer.controller
 	 * @name TestResultDiffController
@@ -68,7 +68,7 @@
 
 		/**
 		 * The &quot;Logic&quot; class
-		 * 
+		 *
 		 * @type Logic
 		 * @memberOf hifive.test.explorer.controller.TestResultDiffController
 		 */
@@ -77,7 +77,7 @@
 		/**
 		 * Called after the controller has been initialized.<br>
 		 * Get the id of the right screenshot, and update views.
-		 * 
+		 *
 		 * @memberOf hifive.test.explorer.controller.TestResultDiffController
 		 */
 		__ready: function() {
@@ -157,7 +157,7 @@
 
 		/**
 		 * Show actual image.
-		 * 
+		 *
 		 * @memberOf hifive.test.explorer.controller.TestResultDiffController
 		 * @param {Boolean} withMarker whether or not to display the image with markers.
 		 * @param {Object} params extra paramters
@@ -168,7 +168,7 @@
 
 		/**
 		 * Show expected image.
-		 * 
+		 *
 		 * @memberOf hifive.test.explorer.controller.TestResultDiffController
 		 * @param {Boolean} withMarker whether or not to display the image with markers.
 		 * @param {Object} params extra paramters
@@ -199,7 +199,7 @@
 
 		/**
 		 * Show image.
-		 * 
+		 *
 		 * @memberOf hifive.test.explorer.controller.TestResultDiffController
 		 * @param {String} selector jQuery selector expression which determines the image node
 		 * @param {Boolean} withMarker whether or not to display the image with markers.

--- a/hifive-test-explorer/src/main/webapp/src/diff.js
+++ b/hifive-test-explorer/src/main/webapp/src/diff.js
@@ -179,6 +179,7 @@
 		 * @param {Number} actualId ID of actual image
 		 */
 		_initEdgeOverlapping: function(expectedId, actualId) {
+			// Initialize <canvas>
 			var expected = new Image(), actual = new Image();
 
 			var d1 = $.Deferred(), d2 = $.Deferred();
@@ -191,13 +192,36 @@
 
 			$.when.apply($, [d1.promise(), d2.promise()]).done(function() {
 				var canvas = $('#edge-overlapping canvas')[0];
-				canvas.width = expected.width;
-				canvas.height = expected.height;
+				var native_width  = canvas.width  = expected.width;
+				var native_height = canvas.height = expected.height;
 
 				var context = canvas.getContext('2d');
 				context.globalCompositeOperation = 'multiply';
 				context.drawImage(expected, 0, 0);
 				context.drawImage(actual, 0, 0);
+
+				// Image magnifier
+				$('.large').css('background-image', 'url('+canvas.toDataURL('image/png')+')');
+				$('#edge-overlapping .image-overlay').mousemove(function(e) {
+					var magnify_offset = $(this).offset();
+					var mx = e.pageX - magnify_offset.left;
+					var my = e.pageY - magnify_offset.top;
+
+					if(mx < $(this).width() && my < $(this).height() && mx > 0 && my > 0) {
+						$('.large').fadeIn(100);
+					} else {
+						$('.large').fadeOut(100);
+					} if($('.large').is(':visible')) {
+						var rx = Math.round(mx/$('.small').width()*native_width - $('.large').width()/2)*-1;
+						var ry = Math.round(my/$('.small').height()*native_height - $('.large').height()/2)*-1;
+
+						$('.large').css({
+							left: mx - $('.large').width()/2,
+							top: my - $('.large').height()/2,
+							backgroundPosition: rx + 'px ' + ry + 'px'
+						});
+					}
+				})
 			});
 		},
 

--- a/hifive-test-explorer/src/main/webapp/src/diff.js
+++ b/hifive-test-explorer/src/main/webapp/src/diff.js
@@ -133,12 +133,7 @@
 						});
 					}
 
-					this._setActualEdgeImageSrc({
-						id: id
-					});
-					this._setExpectedEdgeImageSrc({
-						id: result.id
-					});
+					this._initEdgeOverlapping(result.id, id);
 				}));
 			}));
 
@@ -177,24 +172,33 @@
 			this._setImageSrc('.expected img', withMarker, params);
 		},
 
-		/**
-		 * Show actual edge image.
-		 *
-		 * @memberOf hifive.test.explorer.controller.TestResultDiffController
-		 * @param {Object} params extra paramters
-		 */
-		_setActualEdgeImageSrc: function(params) {
-			this._setEdgeImageSrc('.actual-edge img', jQuery.extend({colorIndex: 0}, params));
-		},
 
 		/**
-		 * Show expected edge image.
-		 *
 		 * @memberOf hifive.test.explorer.controller.TestResultDiffController
-		 * @param {Object} params extra paramters
+		 * @param {Number} expectedId ID of expected image
+		 * @param {Number} actualId ID of actual image
 		 */
-		_setExpectedEdgeImageSrc: function(params) {
-			this._setEdgeImageSrc('.expected-edge img', jQuery.extend({colorIndex: 1}, params));
+		_initEdgeOverlapping: function(expectedId, actualId) {
+			var expected = new Image(), actual = new Image();
+
+			var d1 = $.Deferred(), d2 = $.Deferred();
+			expected.onload = d1.resolve;
+			actual.onload = d2.resolve;
+
+			var format = hifive.test.explorer.utils.formatUrl;
+			expected.src = format('image/getEdge', { id: expectedId, colorIndex: 1 });
+			actual.src = format('image/getEdge', { id: actualId, colorIndex: 0 });
+
+			$.when.apply($, [d1.promise(), d2.promise()]).done(function() {
+				var canvas = $('#edge-overlapping canvas')[0];
+				canvas.width = expected.width;
+				canvas.height = expected.height;
+
+				var context = canvas.getContext('2d');
+				context.globalCompositeOperation = 'multiply';
+				context.drawImage(expected, 0, 0);
+				context.drawImage(actual, 0, 0);
+			});
 		},
 
 		/**
@@ -207,18 +211,6 @@
 		 */
 		_setImageSrc: function(selector, withMarker, params) {
 			var url = withMarker ? 'image/getDiff' : 'image/get';
-			this.$find(selector).attr('src', hifive.test.explorer.utils.formatUrl(url, params));
-		},
-
-		/**
-		 * Show edge image.
-		 *
-		 * @memberOf hifive.test.explorer.controller.TestResultDiffController
-		 * @param {String} selector jQuery selector expression which determines the image node
-		 * @param {Object} params extra paramters
-		 */
-		_setEdgeImageSrc: function(selector, params) {
-			var url = 'image/getEdge';
 			this.$find(selector).attr('src', hifive.test.explorer.utils.formatUrl(url, params));
 		},
 


### PR DESCRIPTION
1.  Used `InputStream` instead of `ImageIO`.
   
   이거 해서 많이 빨라지긴 했는데, 에지디텍터나 getDiff 는 BufferedImage를 쓰기때문에 ImageIO를 피할수가 없어서 여전히 느림. 테스트가 통과한경우를 볼때엔 쌩 스크린샷 파일을 그대로 출력하기때문에 꽤 빠르게 작동하는데, 테스트가 실패한 경우를 볼때엔 별 차이 없음.
2.  Simplified `ImageController`.
   
   쓸데없이 여러개로 쪼개진 함수 하나로 합침.
3.  Show white background instead of black background in _Edge overlapping_ diff view.
   
   회사에서 그때 흰바탕이 더 보기 좋다고 그랬음.
4.  Use _multiply_ as a blend mode for _Edge overlapping_ view instead of _alpha_.
   
   이러면 Expected 엣지랑 Actual 엣지 겹치는곳이 검정색으로 표시됨.
5.  Use HTML5 `<canvas>` to overlap two image.
   
   ``` js
   var canvas = document.getElementById('myCanvas');
   var context = canvas.getContext('2d');
   var img = new Image();
   
   img.onload = function() {
     context.drawImage(img, 69, 50);
   };
   img.src = 'http://www.html5canvastutorials.com/demos/assets/darth-vader.jpg';
   ```
6.  Implemented **image magnifier** only for _Edge overlapping_ mode.
   
   ![](https://hifive-snu.github.io/hifive-test-explorer/img1.png)

Closes #17, #19
