### PR TITLE
Use hash location to remember page position

### DIFF
--- a/hifive-test-explorer/src/main/webapp/list.html
+++ b/hifive-test-explorer/src/main/webapp/list.html
@@ -64,7 +64,7 @@
 						var currentPage = testExecutionsPage.number + 1;
 						var totalPages = testExecutionsPage.totalPages;
 						if (!testExecutionsPage.first) {
-							%]<li><a class="btn-page btn-first-page" href="#" data-page="1">&lt;&lt;</a></li>[%
+							%]<li><a class="btn-page btn-first-page" href="#0" data-page="1">&lt;&lt;</a></li>[%
 						} else {
 							%]<li class="disabled"><a>&lt;&lt;</a></li>[%
 						}
@@ -72,9 +72,10 @@
 					[%
 						var start = Math.max(1, currentPage - 5);
 						var end = Math.min(totalPages, currentPage + 5);
+						var size = testExecutionsPage.size;
 						for (var i = start; i <= end; i++) {
 							if (i != currentPage) {
-								%]<li><a class="btn-page" href="#" data-page="[%= i %]">[%= i %]</a></li>[%
+								%]<li><a class="btn-page" href="#[%= (i-1)*size %]" data-page="[%= i %]">[%= i %]</a></li>[%
 							} else {
 								%]<li class="active"><a>[%= i %]</a></li>[%
 							}
@@ -82,7 +83,7 @@
 					%]
 					[%
 						if (!testExecutionsPage.last) {
-							%]<li><a class="btn-page btn-last-page" href="#" data-page="[%= totalPages %]">&gt;&gt;</a></li>[%
+							%]<li><a class="btn-page btn-last-page" href="#[%= (totalPages-1)*size %]" data-page="[%= totalPages %]">&gt;&gt;</a></li>[%
 						} else {
 							%]<li class="disabled"><a>&gt;&gt;</a></li>[%
 						}

--- a/hifive-test-explorer/src/main/webapp/src/list.js
+++ b/hifive-test-explorer/src/main/webapp/src/list.js
@@ -24,12 +24,12 @@
 		pageSize: 20,
 
 		/**
-		 * The index of the item at the top of the current page.
+		 * The 0-based index of the item at the top of the current page.
 		 *
 		 * @type Number
 		 * @memberOf hifive.test.explorer.logic.TestResultListLogic
 		 */
-		pageStart: 1,
+		pageStart: 0,
 
 		/**
 		 * The search keyword for test method.
@@ -123,7 +123,8 @@
 		 * @memberOf hifive.test.explorer.controller.TestResultListController
 		 */
 		__ready: function() {
-			this.loadTestExecutionList(1);
+			this.onHashChange();
+			$(window).on('hashchange', this.own(this.onHashChange));
 		},
 
 		/**
@@ -228,22 +229,6 @@
 		},
 
 		/**
-		 * Called when the page link has been clicked. Update view.
-		 *
-		 * @memberOf hifive.test.explorer.controller.TestResultListController
-		 * @param {Object} context the event context
-		 * @param {jQuery} $el the event target element
-		 */
-		'.pagination a click': function(context, $el) {
-			var page = $el.data('page');
-			if (typeof page == 'undefined') {
-				(console && console.error && console.error('page undefined'));
-				return;
-			}
-			this.loadTestExecutionList(page);
-		},
-
-		/**
 		 * Called when the page size select value has been changed. Updates view.
 		 *
 		 * @memberOf hifive.test.explorer.controller.TestResultListController
@@ -251,14 +236,36 @@
 		 * @param {jQuery} $el the event target element
 		 */
 		'#select-page-size change': function(context, $el) {
-			// update pagination parameters
 			var pageSize = $el.val();
 			var pageStart = this._testResultListLogic.pageStart;
-			pageStart = Math.floor(pageStart / pageSize) * pageSize;
+			this.updatePageSize(pageSize, pageStart);
+		},
 
-			var page = 1 + Math.floor(pageStart / pageSize);
+		/**
+		 * Called when the page link has been clicked. Update view.
+		 *
+		 * @memberOf hifive.test.explorer.controller.TestResultListController
+		 */
+		onHashChange: function(){
+			var pageSize = $("#select-page-size").val();
+			var pageStart = Math.max(0, parseInt(window.location.hash.substr(1)));
+			if (isNaN(pageStart)) { pageStart = 0; }
 
+			this.updatePageSize(pageSize, pageStart);
+		},
+
+		/**
+		 * Set pageSize and pageStart, and update view.
+		 *
+		 * @memberOf hifive.test.explorer.controller.TestResultListController
+		 * @param {number} pageSize new page size
+		 * @param {number} pageStart new page start
+		 */
+		updatePageSize: function(pageSize, pageStart) {
+			// update pagination parameters
+			this._testResultListLogic.pageStart = pageStart;
 			this._testResultListLogic.pageSize = pageSize;
+			var page = 1 + Math.floor(pageStart / pageSize);
 			this.loadTestExecutionList(page);
 		},
 


### PR DESCRIPTION
This change allows users to use browser history feature
Also the list will remain same when moved back from the diff page.
